### PR TITLE
enabling a custom header on an attachment

### DIFF
--- a/message.go
+++ b/message.go
@@ -117,10 +117,15 @@ func (m *Message) GetHeader(header string) string {
 	return decoded
 }
 
-// SetHeader adds header to the list of headers and sets it to quoted-printable
+// SetHeader adds (overwrites) header to the list of headers and sets it to quoted-printable
 // encoded value.
 func (m *Message) SetHeader(header, value string) {
 	textproto.MIMEHeader(m.Header).Set(header, value)
+}
+// AddHeader adds (appends) header to the list of headers and sets it to quoted-printable
+// encoded value.
+func (m *Message) AddHeader(header, value string) {
+	textproto.MIMEHeader(m.Header).Add(header, value)
 }
 
 // Subject line of the message.

--- a/message_test.go
+++ b/message_test.go
@@ -62,7 +62,7 @@ func ExampleMessage_mixed() {
 	alternative.AddText("text/plain", text)
 	alternative.AddText("text/html", html)
 	alternative.Close()
-	mixed.AddAttachment(Attachment, "Photo", "image/jpeg", attachment)
+	mixed.AddAttachment(Attachment, "Photo", "image/jpeg", attachment, nil)
 	mixed.Close()
 
 	fmt.Println(msg)


### PR DESCRIPTION
I needed to be able to set custom headers on an inline attachment, so have made it possible to now pass in a header of type `map[string][]string` to the `AddAttachment` function. 
If you don't want to have to pass in a header, you can just pass in nil, and it will use the default